### PR TITLE
Fix npm package reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ or
 then 
 
 ```javascript
-import { clusterData } from 'hclust';
-import { euclideanDistance } from 'hclust';
-import { avgDistance } from 'hclust';
+import { clusterData } from '@greenelab/hclust';
+import { euclideanDistance } from '@greenelab/hclust';
+import { avgDistance } from '@greenelab/hclust';
 ```
 
 ---


### PR DESCRIPTION
Changes the namespace that the package is imported from, since the npm package referenced by 'hclust' i think is slightly different https://www.npmjs.com/package/hclust